### PR TITLE
Added command to run with cargo in terminal

### DIFF
--- a/Commands/Run with Cargo (external).tmCommand
+++ b/Commands/Run with Cargo (external).tmCommand
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>beforeRunningCommand</key>
+        <string>saveModifiedFiles</string>
+        <key>command</key>
+        <string>#!/bin/bash
+esc () {
+STR="$1" ruby18 &lt;&lt;"RUBY"
+   str = ENV['STR']
+   str = str.gsub(/'/, "'\\\\''")
+   str = str.gsub(/[\\"]/, '\\\\\\0')
+   print "'#{str}'"
+RUBY
+}
+
+osascript &lt;&lt;- APPLESCRIPT
+	tell app "Terminal"
+	    launch
+	    activate
+	    do script "clear; cd $(esc "${TM_DIRECTORY}")\ncargo run"
+	    set position of first window to { 100, 100 }
+	end tell
+APPLESCRIPT
+
+</string>
+        <key>input</key>
+        <string>document</string>
+        <key>inputFormat</key>
+        <string>text</string>
+        <key>keyEquivalent</key>
+        <string>@R</string>
+        <key>name</key>
+        <string>Cargo</string>
+        <key>outputCaret</key>
+        <string>afterOutput</string>
+        <key>outputFormat</key>
+        <string>html</string>
+        <key>outputLocation</key>
+        <string>discard</string>
+        <key>scope</key>
+        <string>source.rs</string>
+        <key>semanticClass</key>
+        <string>process.external.run.rust</string>
+        <key>uuid</key>
+        <string>22D8F169-BE9C-4E06-B704-83F388340324</string>
+        <key>version</key>
+        <integer>2</integer>
+    </dict>
+</plist>


### PR DESCRIPTION
Added command to run the rust project with cargo. (Assumes that the current project uses cargo)
- Key combo SHIFT + COMMAND + R
