### PR TITLE
Miscellaneous TextMate Changes

### DIFF
--- a/Commands/Cargo Build.tmCommand
+++ b/Commands/Cargo Build.tmCommand
@@ -27,15 +27,23 @@ APPLESCRIPT
 </string>
 	<key>input</key>
 	<string>document</string>
+	<key>inputFormat</key>
+	<string>text</string>
 	<key>keyEquivalent</key>
 	<string>@B</string>
 	<key>name</key>
 	<string>Cargo Build</string>
+	<key>outputCaret</key>
+	<string>afterOutput</string>
+	<key>outputFormat</key>
+	<string>text</string>
 	<key>outputLocation</key>
 	<string>discard</string>
 	<key>scope</key>
-	<string>source.rs</string>
+	<string>source.rust</string>
 	<key>uuid</key>
 	<string>D5624A49-9460-43C7-9D05-39580911371C</string>
+	<key>version</key>
+	<integer>2</integer>
 </dict>
 </plist>

--- a/Commands/Cargo Test.tmCommand
+++ b/Commands/Cargo Test.tmCommand
@@ -40,7 +40,7 @@ APPLESCRIPT
 	<key>outputLocation</key>
 	<string>discard</string>
 	<key>scope</key>
-	<string>source.rs</string>
+	<string>source.rust</string>
 	<key>uuid</key>
 	<string>CB93B58D-AAD0-453B-BF18-727E1D588A96</string>
 	<key>version</key>

--- a/Commands/Compile with tests.tmCommand
+++ b/Commands/Compile with tests.tmCommand
@@ -26,7 +26,7 @@ cd "${TM_PROJECT_DIRECTORY:-$TM_DIRECTORY}"
 	<key>outputLocation</key>
 	<string>newWindow</string>
 	<key>scope</key>
-	<string>source.rs</string>
+	<string>source.rust</string>
 	<key>uuid</key>
 	<string>AE3EDDD9-4C26-4107-AFB3-23E80044C531</string>
 	<key>version</key>

--- a/Commands/Compile with tests.tmCommand
+++ b/Commands/Compile with tests.tmCommand
@@ -9,7 +9,7 @@
 [[ -f "${TM_SUPPORT_PATH}/lib/bash_init.sh" ]] &amp;&amp; . "${TM_SUPPORT_PATH}/lib/bash_init.sh"
 
 cd "${TM_PROJECT_DIRECTORY:-$TM_DIRECTORY}"
-/usr/local/bin/rustc --test $TM_FILEPATH
+"$TM_RUST" --test "$TM_FILEPATH"
 </string>
 	<key>input</key>
 	<string>document</string>
@@ -25,6 +25,20 @@ cd "${TM_PROJECT_DIRECTORY:-$TM_DIRECTORY}"
 	<string>html</string>
 	<key>outputLocation</key>
 	<string>newWindow</string>
+	<key>requiredCommands</key>
+	<array>
+		<dict>
+			<key>command</key>
+			<string>rustc</string>
+			<key>locations</key>
+			<array>
+				<string>/usr/local/bin/rustc</string>
+				<string>/opt/local/bin/rustc</string>
+			</array>
+			<key>variable</key>
+			<string>TM_RUST</string>
+		</dict>
+	</array>
 	<key>scope</key>
 	<string>source.rust</string>
 	<key>uuid</key>

--- a/Commands/Compile with tests.tmCommand
+++ b/Commands/Compile with tests.tmCommand
@@ -6,7 +6,6 @@
 	<string>saveActiveFile</string>
 	<key>command</key>
 	<string>#!/bin/bash
-[[ -f "${TM_SUPPORT_PATH}/lib/bash_init.sh" ]] &amp;&amp; . "${TM_SUPPORT_PATH}/lib/bash_init.sh"
 
 cd "${TM_PROJECT_DIRECTORY:-$TM_DIRECTORY}"
 "$TM_RUST" --test "$TM_FILEPATH"

--- a/Commands/Compile with tests.tmCommand
+++ b/Commands/Compile with tests.tmCommand
@@ -18,7 +18,7 @@ cd "${TM_PROJECT_DIRECTORY:-$TM_DIRECTORY}"
 	<key>keyEquivalent</key>
 	<string>@A</string>
 	<key>name</key>
-	<string>Compile with tests</string>
+	<string>Compile With Tests</string>
 	<key>outputCaret</key>
 	<string>afterOutput</string>
 	<key>outputFormat</key>

--- a/Commands/Compile.tmCommand
+++ b/Commands/Compile.tmCommand
@@ -6,7 +6,6 @@
 	<string>saveActiveFile</string>
 	<key>command</key>
 	<string>#!/bin/bash
-[[ -f "${TM_SUPPORT_PATH}/lib/bash_init.sh" ]] &amp;&amp; . "${TM_SUPPORT_PATH}/lib/bash_init.sh"
 
 cd "${TM_PROJECT_DIRECTORY:-$TM_DIRECTORY}"
 "$TM_RUST" "$TM_FILEPATH"

--- a/Commands/Compile.tmCommand
+++ b/Commands/Compile.tmCommand
@@ -9,7 +9,7 @@
 [[ -f "${TM_SUPPORT_PATH}/lib/bash_init.sh" ]] &amp;&amp; . "${TM_SUPPORT_PATH}/lib/bash_init.sh"
 
 cd "${TM_PROJECT_DIRECTORY:-$TM_DIRECTORY}"
-/usr/local/bin/rustc $TM_FILEPATH
+"$TM_RUST" "$TM_FILEPATH"
 </string>
 	<key>input</key>
 	<string>document</string>
@@ -25,6 +25,20 @@ cd "${TM_PROJECT_DIRECTORY:-$TM_DIRECTORY}"
 	<string>html</string>
 	<key>outputLocation</key>
 	<string>newWindow</string>
+	<key>requiredCommands</key>
+	<array>
+		<dict>
+			<key>command</key>
+			<string>rustc</string>
+			<key>locations</key>
+			<array>
+				<string>/usr/local/bin/rustc</string>
+				<string>/opt/local/bin/rustc</string>
+			</array>
+			<key>variable</key>
+			<string>TM_RUST</string>
+		</dict>
+	</array>
 	<key>scope</key>
 	<string>source.rust</string>
 	<key>uuid</key>

--- a/Commands/Compile.tmCommand
+++ b/Commands/Compile.tmCommand
@@ -26,7 +26,7 @@ cd "${TM_PROJECT_DIRECTORY:-$TM_DIRECTORY}"
 	<key>outputLocation</key>
 	<string>newWindow</string>
 	<key>scope</key>
-	<string>source.rs</string>
+	<string>source.rust</string>
 	<key>uuid</key>
 	<string>A7DF7817-C437-464D-9A12-BA23CB4AE9B9</string>
 	<key>version</key>

--- a/Commands/New Function.tmCommand
+++ b/Commands/New Function.tmCommand
@@ -13,6 +13,8 @@ fn ${TM_SELECTED_TEXT:-$TM_CURRENT_WORD}(\${1:args}) {
 	\$0
 }
 SNIPPET</string>
+	<key>fallbackInput</key>
+	<string>word</string>
 	<key>input</key>
 	<string>selection</string>
 	<key>inputFormat</key>

--- a/Commands/New Function.tmCommand
+++ b/Commands/New Function.tmCommand
@@ -6,7 +6,6 @@
 	<string>nop</string>
 	<key>command</key>
 	<string>#!/bin/bash
-[[ -f "${TM_SUPPORT_PATH}/lib/bash_init.sh" ]] &amp;&amp; . "${TM_SUPPORT_PATH}/lib/bash_init.sh"
 
 cat &lt;&lt;SNIPPET
 fn ${TM_SELECTED_TEXT:-$TM_CURRENT_WORD}(\${1:args}) {

--- a/Commands/New Function.tmCommand
+++ b/Commands/New Function.tmCommand
@@ -5,18 +5,31 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>cat &lt;&lt;SNIPPET
+	<string>#!/bin/bash
+[[ -f "${TM_SUPPORT_PATH}/lib/bash_init.sh" ]] &amp;&amp; . "${TM_SUPPORT_PATH}/lib/bash_init.sh"
+
+cat &lt;&lt;SNIPPET
 fn ${TM_SELECTED_TEXT:-$TM_CURRENT_WORD}(\${1:args}) {
 	\$0
 }
 SNIPPET</string>
 	<key>input</key>
 	<string>selection</string>
+	<key>inputFormat</key>
+	<string>text</string>
 	<key>name</key>
 	<string>New Function</string>
-	<key>output</key>
-	<string>replaceSelectedText</string>
+	<key>outputCaret</key>
+	<string>heuristic</string>
+	<key>outputFormat</key>
+	<string>text</string>
+	<key>outputLocation</key>
+	<string>replaceInput</string>
+	<key>scope</key>
+	<string>source.rs</string>
 	<key>uuid</key>
 	<string>BFC654BE-E20E-4AAE-BCF9-638751DD3BBF</string>
+	<key>version</key>
+	<integer>2</integer>
 </dict>
 </plist>

--- a/Commands/New Function.tmCommand
+++ b/Commands/New Function.tmCommand
@@ -26,7 +26,7 @@ SNIPPET</string>
 	<key>outputLocation</key>
 	<string>replaceInput</string>
 	<key>scope</key>
-	<string>source.rs</string>
+	<string>source.rust</string>
 	<key>uuid</key>
 	<string>BFC654BE-E20E-4AAE-BCF9-638751DD3BBF</string>
 	<key>version</key>

--- a/Commands/Run with Cargo (external).tmCommand
+++ b/Commands/Run with Cargo (external).tmCommand
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-    <dict>
-        <key>beforeRunningCommand</key>
-        <string>saveModifiedFiles</string>
-        <key>command</key>
-        <string>#!/bin/bash
+<dict>
+	<key>beforeRunningCommand</key>
+	<string>saveModifiedFiles</string>
+	<key>command</key>
+	<string>#!/bin/bash
 esc () {
 STR="$1" ruby18 &lt;&lt;"RUBY"
    str = ENV['STR']
@@ -40,7 +40,7 @@ APPLESCRIPT
 	<key>outputLocation</key>
 	<string>discard</string>
 	<key>scope</key>
-	<string>source.rs</string>
+	<string>source.rust</string>
 	<key>semanticClass</key>
 	<string>process.external.run.rust</string>
 	<key>uuid</key>

--- a/Commands/Run.tmCommand
+++ b/Commands/Run.tmCommand
@@ -33,7 +33,7 @@ TextMate::Executor.run(args, :version_args =&gt; ["--version"],
 	<key>outputLocation</key>
 	<string>newWindow</string>
 	<key>scope</key>
-	<string>source.rs</string>
+	<string>source.rust</string>
 	<key>semanticClass</key>
 	<string>process.run.rust</string>
 	<key>uuid</key>

--- a/Commands/Run.tmCommand
+++ b/Commands/Run.tmCommand
@@ -14,7 +14,7 @@ require "shellwords"
 TextMate.save_if_untitled('rs')
 TextMate::Executor.make_project_master_current_document
 TextMate::Process.run(["cd", ENV['TM_PROJECT_DIRECTORY'] || ENV['TM_DIRECTORY']])
-args = Shellwords.split(ENV['TM_RUST'] || '/usr/local/bin/rustc') &lt;&lt; ENV['TM_FILEPATH']
+args = Shellwords.split(ENV['TM_RUST']) &lt;&lt; ENV['TM_FILEPATH']
 TextMate::Executor.run(args, :version_args =&gt; ["--version"],
                              :version_regex =&gt; /\Arustc ([^\n]*)\n.*/m)
 </string>
@@ -32,6 +32,20 @@ TextMate::Executor.run(args, :version_args =&gt; ["--version"],
 	<string>html</string>
 	<key>outputLocation</key>
 	<string>newWindow</string>
+	<key>requiredCommands</key>
+	<array>
+		<dict>
+			<key>command</key>
+			<string>rustc</string>
+			<key>locations</key>
+			<array>
+				<string>/usr/local/bin/rustc</string>
+				<string>/opt/local/bin/rustc</string>
+			</array>
+			<key>variable</key>
+			<string>TM_RUST</string>
+		</dict>
+	</array>
 	<key>scope</key>
 	<string>source.rust</string>
 	<key>semanticClass</key>

--- a/Commands/Test.tmCommand
+++ b/Commands/Test.tmCommand
@@ -13,7 +13,7 @@ require "shellwords"
 
 TextMate.save_if_untitled('rs')
 TextMate::Executor.make_project_master_current_document
-args = Shellwords.split(ENV['TM_RUST'] || '/usr/local/bin/rustc') 
+args = Shellwords.split(ENV['TM_RUST']) 
 args &lt;&lt; '--test'
 args &lt;&lt; ENV['TM_FILEPATH']
 TextMate::Process.run(["cd", ENV['TM_PROJECT_DIRECTORY'] || ENV['TM_DIRECTORY']])
@@ -34,6 +34,20 @@ TextMate::Executor.run(args, :version_args =&gt; ["--version"],
 	<string>html</string>
 	<key>outputLocation</key>
 	<string>newWindow</string>
+	<key>requiredCommands</key>
+	<array>
+		<dict>
+			<key>command</key>
+			<string>rustc</string>
+			<key>locations</key>
+			<array>
+				<string>/usr/local/bin/rustc</string>
+				<string>/opt/local/bin/rustc</string>
+			</array>
+			<key>variable</key>
+			<string>TM_RUST</string>
+		</dict>
+	</array>
 	<key>scope</key>
 	<string>source.rust</string>
 	<key>uuid</key>

--- a/Commands/Test.tmCommand
+++ b/Commands/Test.tmCommand
@@ -35,7 +35,7 @@ TextMate::Executor.run(args, :version_args =&gt; ["--version"],
 	<key>outputLocation</key>
 	<string>newWindow</string>
 	<key>scope</key>
-	<string>source.rs</string>
+	<string>source.rust</string>
 	<key>uuid</key>
 	<string>299EB188-E7AE-4C55-BBCE-17EA4337F3FA</string>
 	<key>version</key>

--- a/Preferences/Comments.tmPreferences
+++ b/Preferences/Comments.tmPreferences
@@ -5,7 +5,7 @@
 	<key>name</key>
 	<string>Comments</string>
 	<key>scope</key>
-	<string>source.rs</string>
+	<string>source.rust</string>
 	<key>settings</key>
 	<dict>
 		<key>shellVariables</key>

--- a/Preferences/Comments.tmPreferences
+++ b/Preferences/Comments.tmPreferences
@@ -37,41 +37,6 @@
 */</string>
 			</dict>
 		</array>
-		<key>smartTypingPairs</key>
-		<array>
-			<array>
-				<string>"</string>
-				<string>"</string>
-			</array>
-			<array>
-				<string>(</string>
-				<string>)</string>
-			</array>
-			<array>
-				<string>{</string>
-				<string>}</string>
-			</array>
-			<array>
-				<string>[</string>
-				<string>]</string>
-			</array>
-			<array>
-				<string>“</string>
-				<string>”</string>
-			</array>
-			<array>
-				<string>‘</string>
-				<string>’</string>
-			</array>
-			<array>
-				<string>&lt;</string>
-				<string>&gt;</string>
-			</array>
-			<array>
-				<string>`</string>
-				<string>`</string>
-			</array>
-		</array>
 	</dict>
 	<key>uuid</key>
 	<string>C4C70D88-6B26-45A3-828B-13FDB8F24D2E</string>

--- a/Preferences/Folding.tmPreferences
+++ b/Preferences/Folding.tmPreferences
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>name</key>
+	<string>Folding</string>
+	<key>scope</key>
+	<string>source.rust</string>
+	<key>settings</key>
+	<dict>
+		<key>foldingStartMarker</key>
+		<string>^.*\bfn\s*(\w+\s*)?\([^\)]*\)(\s*\{[^\}]*)?\s*$</string>
+		<key>foldingStopMarker</key>
+		<string>^\s*\}</string>
+	</dict>
+	<key>uuid</key>
+	<string>D3DFA89E-BA28-4225-A815-E7C84BDA88CF</string>
+</dict>
+</plist>

--- a/Preferences/Indent.tmPreferences
+++ b/Preferences/Indent.tmPreferences
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>name</key>
-	<string>Rust Indent</string>
+	<string>Indent</string>
 	<key>scope</key>
 	<string>source.rust</string>
 	<key>settings</key>

--- a/Preferences/Rust Indent.tmPreferences
+++ b/Preferences/Rust Indent.tmPreferences
@@ -5,7 +5,7 @@
 	<key>name</key>
 	<string>Rust Indent</string>
 	<key>scope</key>
-	<string>source.rs</string>
+	<string>source.rust</string>
 	<key>settings</key>
 	<dict>
 		<key>decreaseIndentPattern</key>

--- a/Preferences/Rust Indent.tmPreferences
+++ b/Preferences/Rust Indent.tmPreferences
@@ -4,6 +4,8 @@
 <dict>
 	<key>name</key>
 	<string>Rust Indent</string>
+	<key>scope</key>
+	<string>source.rs</string>
 	<key>settings</key>
 	<dict>
 		<key>decreaseIndentPattern</key>

--- a/Preferences/Typing Pairs.tmPreferences
+++ b/Preferences/Typing Pairs.tmPreferences
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>name</key>
+	<string>Typing Pairs</string>
+	<key>scope</key>
+	<string>source.rust</string>
+	<key>settings</key>
+	<dict>
+		<key>smartTypingPairs</key>
+		<array>
+			<array>
+				<string>"</string>
+				<string>"</string>
+			</array>
+			<array>
+				<string>(</string>
+				<string>)</string>
+			</array>
+			<array>
+				<string>{</string>
+				<string>}</string>
+			</array>
+			<array>
+				<string>[</string>
+				<string>]</string>
+			</array>
+			<array>
+				<string>“</string>
+				<string>”</string>
+			</array>
+			<array>
+				<string>‘</string>
+				<string>’</string>
+			</array>
+			<array>
+				<string>&lt;</string>
+				<string>&gt;</string>
+			</array>
+			<array>
+				<string>`</string>
+				<string>`</string>
+			</array>
+		</array>
+	</dict>
+	<key>uuid</key>
+	<string>C01912EC-1161-41D4-8964-BBAA3DDA5F9F</string>
+</dict>
+</plist>

--- a/Snippets/If.tmSnippet
+++ b/Snippets/If.tmSnippet
@@ -7,7 +7,7 @@
 	<key>name</key>
 	<string>If</string>
 	<key>scope</key>
-	<string>source.rs</string>
+	<string>source.rust</string>
 	<key>tabTrigger</key>
 	<string>if</string>
 	<key>uuid</key>

--- a/Snippets/fn.tmSnippet
+++ b/Snippets/fn.tmSnippet
@@ -9,7 +9,7 @@
 	<key>name</key>
 	<string>fn</string>
 	<key>scope</key>
-	<string>source.rs</string>
+	<string>source.rust</string>
 	<key>tabTrigger</key>
 	<string>fn</string>
 	<key>uuid</key>

--- a/Snippets/fnr.tmSnippet
+++ b/Snippets/fnr.tmSnippet
@@ -9,7 +9,7 @@
 	<key>name</key>
 	<string>fnr</string>
 	<key>scope</key>
-	<string>source.rs</string>
+	<string>source.rust</string>
 	<key>tabTrigger</key>
 	<string>fnr</string>
 	<key>uuid</key>

--- a/Snippets/let.tmSnippet
+++ b/Snippets/let.tmSnippet
@@ -7,7 +7,7 @@
 	<key>name</key>
 	<string>let</string>
 	<key>scope</key>
-	<string>source.rs</string>
+	<string>source.rust</string>
 	<key>tabTrigger</key>
 	<string>let</string>
 	<key>uuid</key>

--- a/Snippets/main.tmSnippet
+++ b/Snippets/main.tmSnippet
@@ -9,7 +9,7 @@
 	<key>name</key>
 	<string>main</string>
 	<key>scope</key>
-	<string>source.rs</string>
+	<string>source.rust</string>
 	<key>tabTrigger</key>
 	<string>main</string>
 	<key>uuid</key>

--- a/Snippets/main.tmSnippet
+++ b/Snippets/main.tmSnippet
@@ -4,7 +4,7 @@
 <dict>
 	<key>content</key>
 	<string>fn main() {
-    ${1:println!("hello?");}
+	${1:println!("hello?");}
 }</string>
 	<key>name</key>
 	<string>main</string>

--- a/Snippets/mod.tmSnippet
+++ b/Snippets/mod.tmSnippet
@@ -4,7 +4,7 @@
 <dict>
 	<key>content</key>
 	<string>mod ${1:name} {
-  $2
+	$2
 }</string>
 	<key>name</key>
 	<string>mod</string>

--- a/Snippets/mod.tmSnippet
+++ b/Snippets/mod.tmSnippet
@@ -9,7 +9,7 @@
 	<key>name</key>
 	<string>mod</string>
 	<key>scope</key>
-	<string>source.rs</string>
+	<string>source.rust</string>
 	<key>tabTrigger</key>
 	<string>mod</string>
 	<key>uuid</key>

--- a/Snippets/println.tmSnippet
+++ b/Snippets/println.tmSnippet
@@ -7,7 +7,7 @@
 	<key>name</key>
 	<string>println</string>
 	<key>scope</key>
-	<string>source.rs</string>
+	<string>source.rust</string>
 	<key>tabTrigger</key>
 	<string>pl</string>
 	<key>uuid</key>

--- a/Snippets/println.tmSnippet
+++ b/Snippets/println.tmSnippet
@@ -6,6 +6,8 @@
 	<string>std::io::println( ${1:message} );</string>
 	<key>name</key>
 	<string>println</string>
+	<key>scope</key>
+	<string>source.rs</string>
 	<key>tabTrigger</key>
 	<string>pl</string>
 	<key>uuid</key>

--- a/Snippets/struct.tmSnippet
+++ b/Snippets/struct.tmSnippet
@@ -8,7 +8,7 @@
 	<key>name</key>
 	<string>struct</string>
 	<key>scope</key>
-	<string>source.rs</string>
+	<string>source.rust</string>
 	<key>tabTrigger</key>
 	<string>str</string>
 	<key>uuid</key>

--- a/Snippets/use std.tmSnippet
+++ b/Snippets/use std.tmSnippet
@@ -8,7 +8,7 @@
 	<key>name</key>
 	<string>use std</string>
 	<key>scope</key>
-	<string>source.rs</string>
+	<string>source.rust</string>
 	<key>tabTrigger</key>
 	<string>us</string>
 	<key>uuid</key>

--- a/Snippets/use std.tmSnippet
+++ b/Snippets/use std.tmSnippet
@@ -7,6 +7,8 @@
 </string>
 	<key>name</key>
 	<string>use std</string>
+	<key>scope</key>
+	<string>source.rs</string>
 	<key>tabTrigger</key>
 	<string>us</string>
 	<key>uuid</key>

--- a/Syntaxes/Rust.tmLanguage
+++ b/Syntaxes/Rust.tmLanguage
@@ -463,7 +463,7 @@
 			<key>comment</key>
 			<string>Single-line comment</string>
 			<key>match</key>
-			<string>//.*$</string>
+			<string>//.*$\n?</string>
 			<key>name</key>
 			<string>comment.line.double-slash.rust</string>
 		</dict>
@@ -472,7 +472,7 @@
 			<key>comment</key>
 			<string>Single-line documentation comment</string>
 			<key>match</key>
-			<string>//[!/][^/].*$</string>
+			<string>//[!/][^/].*$\n?</string>
 			<key>name</key>
 			<string>comment.line.documentation.rust</string>
 		</dict>

--- a/Syntaxes/Rust.tmLanguage
+++ b/Syntaxes/Rust.tmLanguage
@@ -75,7 +75,12 @@
 					<key>name</key>
 					<string>punctuation.definition.string.begin.rust</string>
 				</dict>
-				<key>4</key>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>constant.character.escape.rust</string>
+				</dict>
+				<key>5</key>
 				<dict>
 					<key>name</key>
 					<string>punctuation.definition.string.end.rust</string>
@@ -84,7 +89,7 @@
 			<key>comment</key>
 			<string>Single-quote string (character literal)</string>
 			<key>match</key>
-			<string>(')([^'\\]|\\(x\h{2}|[0-2][0-7]{0,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.))(')</string>
+			<string>(')([^'\\]|(\\(x\h{2}|[0-2][0-7]{0,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.)))(')</string>
 			<key>name</key>
 			<string>string.quoted.single.rust</string>
 		</dict>

--- a/Syntaxes/Rust.tmLanguage
+++ b/Syntaxes/Rust.tmLanguage
@@ -84,7 +84,7 @@
 			<key>comment</key>
 			<string>Single-quote string (character literal)</string>
 			<key>match</key>
-			<string>(')([^'\\]|\\(x\h{2}|[0-2][0-7]{,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.))(')</string>
+			<string>(')([^'\\]|\\(x\h{2}|[0-2][0-7]{0,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.))(')</string>
 			<key>name</key>
 			<string>string.quoted.single.rust</string>
 		</dict>
@@ -489,7 +489,7 @@
 		<key>escaped_character</key>
 		<dict>
 			<key>match</key>
-			<string>\\(x\h{2}|[0-2][0-7]{,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.)</string>
+			<string>\\(x\h{2}|[0-2][0-7]{0,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.)</string>
 			<key>name</key>
 			<string>constant.character.escape.rust</string>
 		</dict>

--- a/Syntaxes/Rust.tmLanguage
+++ b/Syntaxes/Rust.tmLanguage
@@ -485,6 +485,17 @@
 			<key>name</key>
 			<string>storage.modifier.mut.rust</string>
 		</dict>
+		<key>raw_string</key>
+		<dict>
+			<key>begin</key>
+			<string>r#"</string>
+			<key>comment</key>
+			<string>Raw string</string>
+			<key>end</key>
+			<string>"#</string>
+			<key>name</key>
+			<string>string.unquoted.rust</string>
+		</dict>
 		<key>ref_lifetime</key>
 		<dict>
 			<key>captures</key>
@@ -550,17 +561,6 @@
 				</dict>
 			</array>
 		</dict>
-		<key>raw_string</key>
-		<dict>
-			<key>begin</key>
-			<string>r#"</string>
-			<key>comment</key>
-			<string>Raw string</string>
-			<key>end</key>
-			<string>"#</string>
-			<key>name</key>
-			<string>string.unquoted.rust</string>
-		</dict>
 		<key>type_params</key>
 		<dict>
 			<key>begin</key>
@@ -622,7 +622,7 @@
 		</dict>
 	</dict>
 	<key>scopeName</key>
-	<string>source.rs</string>
+	<string>source.rust</string>
 	<key>uuid</key>
 	<string>E54FA931-0668-4496-8922-F91520AD02B3</string>
 </dict>

--- a/Syntaxes/Rust.tmLanguage
+++ b/Syntaxes/Rust.tmLanguage
@@ -6,10 +6,6 @@
 	<array>
 		<string>rs</string>
 	</array>
-	<key>foldingStartMarker</key>
-	<string>^.*\bfn\s*(\w+\s*)?\([^\)]*\)(\s*\{[^\}]*)?\s*$</string>
-	<key>foldingStopMarker</key>
-	<string>^\s*\}</string>
 	<key>keyEquivalent</key>
 	<string>^~R</string>
 	<key>name</key>

--- a/Syntaxes/Rust.tmLanguage
+++ b/Syntaxes/Rust.tmLanguage
@@ -37,10 +37,26 @@
 		<dict>
 			<key>begin</key>
 			<string>#\!?\[</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.attribute.begin.rust</string>
+				</dict>
+			</dict>
 			<key>comment</key>
 			<string>Attribute</string>
 			<key>end</key>
 			<string>\]</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.attribute.end.rust</string>
+				</dict>
+			</dict>
 			<key>name</key>
 			<string>meta.attribute.rust</string>
 			<key>patterns</key>
@@ -52,10 +68,23 @@
 			</array>
 		</dict>
 		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.string.begin.rust</string>
+				</dict>
+				<key>4</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.string.end.rust</string>
+				</dict>
+			</dict>
 			<key>comment</key>
 			<string>Single-quote string (character literal)</string>
 			<key>match</key>
-			<string>'([^'\\]|\\(x\h{2}|[0-2][0-7]{,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.))'</string>
+			<string>(')([^'\\]|\\(x\h{2}|[0-2][0-7]{,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.))(')</string>
 			<key>name</key>
 			<string>string.quoted.single.rust</string>
 		</dict>
@@ -376,10 +405,26 @@
 		<dict>
 			<key>begin</key>
 			<string>/\*</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.comment.begin.rust</string>
+				</dict>
+			</dict>
 			<key>comment</key>
 			<string>Block comment</string>
 			<key>end</key>
 			<string>\*/</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.comment.end.rust</string>
+				</dict>
+			</dict>
 			<key>name</key>
 			<string>comment.block.rust</string>
 			<key>patterns</key>
@@ -398,10 +443,26 @@
 		<dict>
 			<key>begin</key>
 			<string>/\*[!\*][^\*]</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.comment.begin.rust</string>
+				</dict>
+			</dict>
 			<key>comment</key>
 			<string>Block documentation comment</string>
 			<key>end</key>
 			<string>\*/</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.comment.end.rust</string>
+				</dict>
+			</dict>
 			<key>name</key>
 			<string>comment.block.documentation.rust</string>
 			<key>patterns</key>
@@ -460,19 +521,35 @@
 		</dict>
 		<key>line_comment</key>
 		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.comment.rust</string>
+				</dict>
+			</dict>
 			<key>comment</key>
 			<string>Single-line comment</string>
 			<key>match</key>
-			<string>//.*$\n?</string>
+			<string>(//).*$\n?</string>
 			<key>name</key>
 			<string>comment.line.double-slash.rust</string>
 		</dict>
 		<key>line_doc_comment</key>
 		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.comment.rust</string>
+				</dict>
+			</dict>
 			<key>comment</key>
 			<string>Single-line documentation comment</string>
 			<key>match</key>
-			<string>//[!/][^/].*$\n?</string>
+			<string>(//)[!/][^/].*$\n?</string>
 			<key>name</key>
 			<string>comment.line.documentation.rust</string>
 		</dict>
@@ -489,10 +566,26 @@
 		<dict>
 			<key>begin</key>
 			<string>r#"</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.string.begin.rust</string>
+				</dict>
+			</dict>
 			<key>comment</key>
 			<string>Raw string</string>
 			<key>end</key>
 			<string>"#</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.string.end.rust</string>
+				</dict>
+			</dict>
 			<key>name</key>
 			<string>string.unquoted.rust</string>
 		</dict>
@@ -547,10 +640,26 @@
 		<dict>
 			<key>begin</key>
 			<string>"</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.string.begin.rust</string>
+				</dict>
+			</dict>
 			<key>comment</key>
 			<string>Double-quote string</string>
 			<key>end</key>
 			<string>"</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.string.end.rust</string>
+				</dict>
+			</dict>
 			<key>name</key>
 			<string>string.quoted.double.rust</string>
 			<key>patterns</key>
@@ -565,10 +674,26 @@
 		<dict>
 			<key>begin</key>
 			<string>&lt;</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.type_params.begin.rust</string>
+				</dict>
+			</dict>
 			<key>comment</key>
 			<string>Type parameters</string>
 			<key>end</key>
 			<string>&gt;</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.type_params.end.rust</string>
+				</dict>
+			</dict>
 			<key>name</key>
 			<string>meta.type_params.rust</string>
 			<key>patterns</key>

--- a/Syntaxes/Rust.tmLanguage
+++ b/Syntaxes/Rust.tmLanguage
@@ -587,7 +587,7 @@
 				</dict>
 			</dict>
 			<key>name</key>
-			<string>string.unquoted.rust</string>
+			<string>string.quoted.other.raw.rust</string>
 		</dict>
 		<key>ref_lifetime</key>
 		<dict>

--- a/Syntaxes/Rust.tmLanguage
+++ b/Syntaxes/Rust.tmLanguage
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>comment</key>
-	<string>Rust Syntax: version 0.11</string>
 	<key>fileTypes</key>
 	<array>
 		<string>rs</string>

--- a/info.plist
+++ b/info.plist
@@ -2,24 +2,12 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>contactName</key>
+	<string>Carol (Nichols || Goulding)</string>
+	<key>description</key>
+	<string>A general-purpose, multi-paradigm, compiled programming language developed by Mozilla Research.</string>
 	<key>name</key>
 	<string>Rust</string>
-	<key>ordering</key>
-	<array>
-		<string>A7DF7817-C437-464D-9A12-BA23CB4AE9B9</string>
-		<string>AE3EDDD9-4C26-4107-AFB3-23E80044C531</string>
-		<string>C6D4863F-A61B-4284-A5D4-C72F8555CC40</string>
-		<string>E54FA931-0668-4496-8922-F91520AD02B3</string>
-		<string>6FFD6B62-9C68-4732-859D-CFF8C7B57260</string>
-		<string>C4C70D88-6B26-45A3-828B-13FDB8F24D2E</string>
-		<string>BFC654BE-E20E-4AAE-BCF9-638751DD3BBF</string>
-		<string>FF96E55B-A5AC-4F3F-989B-976573ADB670</string>
-		<string>CC6478D8-70FE-42DD-9A03-588D9A9AF552</string>
-		<string>5D83E339-418A-42FB-A6A4-37B8FAA3690E</string>
-		<string>23E9CFF0-E905-48A1-AF7F-4DC5497E0352</string>
-		<string>4B7CF745-DD86-4FDB-8787-3C20B5FB1414</string>
-		<string>E97E2D2A-AF7E-4E32-AEE7-034A13BFE7C2</string>
-	</array>
 	<key>uuid</key>
 	<string>06794A1F-20AC-457C-AD92-A4A8EF83EB0E</string>
 </dict>

--- a/info.plist
+++ b/info.plist
@@ -6,6 +6,32 @@
 	<string>Carol (Nichols || Goulding)</string>
 	<key>description</key>
 	<string>A general-purpose, multi-paradigm, compiled programming language developed by Mozilla Research.</string>
+	<key>mainMenu</key>
+	<dict>
+		<key>items</key>
+		<array>
+			<string>C6D4863F-A61B-4284-A5D4-C72F8555CC40</string>
+			<string>A7DF7817-C437-464D-9A12-BA23CB4AE9B9</string>
+			<string>AE3EDDD9-4C26-4107-AFB3-23E80044C531</string>
+			<string>299EB188-E7AE-4C55-BBCE-17EA4337F3FA</string>
+			<string>------------------------------------</string>
+			<string>22D8F169-BE9C-4E06-B704-83F388340324</string>
+			<string>D5624A49-9460-43C7-9D05-39580911371C</string>
+			<string>CB93B58D-AAD0-453B-BF18-727E1D588A96</string>
+			<string>------------------------------------</string>
+			<string>BFC654BE-E20E-4AAE-BCF9-638751DD3BBF</string>
+			<string>------------------------------------</string>
+			<string>5D83E339-418A-42FB-A6A4-37B8FAA3690E</string>
+			<string>23E9CFF0-E905-48A1-AF7F-4DC5497E0352</string>
+			<string>FF96E55B-A5AC-4F3F-989B-976573ADB670</string>
+			<string>CC6478D8-70FE-42DD-9A03-588D9A9AF552</string>
+			<string>3D3BF360-C3EF-40DE-BCF6-B13393157478</string>
+			<string>CBDE987D-1D3E-491C-8732-3EF203B7079F</string>
+			<string>E97E2D2A-AF7E-4E32-AEE7-034A13BFE7C2</string>
+			<string>8CA955F6-1FBB-44E0-99D7-4E34BA2A736E</string>
+			<string>4B7CF745-DD86-4FDB-8787-3C20B5FB1414</string>
+		</array>
+	</dict>
 	<key>name</key>
 	<string>Rust</string>
 	<key>uuid</key>


### PR DESCRIPTION
After talking with you on twitter the other day I added the bundle to my review list to be added to the bundle installer. Did a review of the bundle mostly in regard to TextMate conventions and new features included in 2.0, nothing really Rust specific.

Made the these changes over the last couple days and just rebased on top of the current state. Ask if you have any questions about any of these changes or any TextMate questions in general.

A few comments and questions left after looking over the bundle:

* For single line snippets half end in a newline, half do not. We don't have any standard for this really, but should be consistant inside the bundle.
* The shortcuts for `Compile`/`Compile With Tests` are non-standard, generally we like to keep these to some combination of R/B and modifier keys. Compile (⇧⌘C) currently conflicts with Go → Computer.
* Question on cargo: Once a project is using cargo will those commands always be used and will a `Cargo.toml` file always be present at the project root?
* Should `Compile` be changed to Build to be consistant with `Cargo Build` or is there a reason for the terminology difference?
* `Compile`/`Compile With Tests` both only save the current document, the other related commands save all modified documents, an oversight?