### PR TITLE
Correct UUID conflict

### DIFF
--- a/Commands/Complete.tmCommand
+++ b/Commands/Complete.tmCommand
@@ -86,7 +86,7 @@ end
 	<key>scope</key>
 	<string>source.rust</string>
 	<key>uuid</key>
-	<string>FE908865-7729-4926-9FAC-2D54895BEA48</string>
+	<string>10B2CC57-CCE0-42B6-BE08-A5C25C33EE46</string>
 	<key>version</key>
 	<integer>2</integer>
 </dict>


### PR DESCRIPTION
This item shares a UUID with an item from the Go bundle, generated a new UUID to correct the conflict.