### PR TITLE
Improve cargo commands

### DIFF
--- a/Commands/Build with tests.tmCommand
+++ b/Commands/Build with tests.tmCommand
@@ -15,7 +15,7 @@ cd "${TM_PROJECT_DIRECTORY:-$TM_DIRECTORY}"
 	<key>inputFormat</key>
 	<string>text</string>
 	<key>keyEquivalent</key>
-	<string>@B</string>
+	<string>@R</string>
 	<key>name</key>
 	<string>Build With Tests</string>
 	<key>outputCaret</key>

--- a/Commands/Build.tmCommand
+++ b/Commands/Build.tmCommand
@@ -15,7 +15,7 @@ cd "${TM_PROJECT_DIRECTORY:-$TM_DIRECTORY}"
 	<key>inputFormat</key>
 	<string>text</string>
 	<key>keyEquivalent</key>
-	<string>@b</string>
+	<string>@R</string>
 	<key>name</key>
 	<string>Build</string>
 	<key>outputCaret</key>

--- a/Commands/Cargo Build.tmCommand
+++ b/Commands/Cargo Build.tmCommand
@@ -3,44 +3,31 @@
 <plist version="1.0">
 <dict>
 	<key>beforeRunningCommand</key>
-	<string>saveActiveFile</string>
+	<string>saveModifiedFiles</string>
 	<key>command</key>
-	<string>#!/bin/bash
-esc () {
-STR="$1" ruby18 &lt;&lt;"RUBY"
-   str = ENV['STR']
-   str = str.gsub(/'/, "'\\\\''")
-   str = str.gsub(/[\\"]/, '\\\\\\0')
-   print "'#{str}'"
-RUBY
-}
+	<string>#!/usr/bin/env ruby
 
-osascript &lt;&lt;- APPLESCRIPT
-	tell app "Terminal"
-	    launch
-	    activate
-	    do script "clear; cd $(esc "${TM_PROJECT_DIRECTORY:-$TM_DIRECTORY}")\ncargo build"
-	    set position of first window to { 100, 100 }
-	end tell
-APPLESCRIPT
+require "#{ENV['TM_BUNDLE_SUPPORT']}/lib/build.rb"
 
-</string>
+run_cargo("build", true)</string>
 	<key>input</key>
 	<string>document</string>
 	<key>inputFormat</key>
 	<string>text</string>
 	<key>keyEquivalent</key>
-	<string>@b</string>
+	<string>@r</string>
 	<key>name</key>
 	<string>Cargo Build</string>
 	<key>outputCaret</key>
 	<string>afterOutput</string>
 	<key>outputFormat</key>
-	<string>text</string>
+	<string>html</string>
 	<key>outputLocation</key>
-	<string>discard</string>
+	<string>newWindow</string>
 	<key>scope</key>
 	<string>attr.project.cargo</string>
+	<key>semanticClass</key>
+	<string>process.external.run.rust</string>
 	<key>uuid</key>
 	<string>D5624A49-9460-43C7-9D05-39580911371C</string>
 	<key>version</key>

--- a/Commands/Cargo Check.tmCommand
+++ b/Commands/Cargo Check.tmCommand
@@ -9,7 +9,7 @@
 
 require "#{ENV['TM_BUNDLE_SUPPORT']}/lib/build.rb"
 
-run_cargo("run", true)</string>
+run_cargo("check", true)</string>
 	<key>input</key>
 	<string>none</string>
 	<key>inputFormat</key>
@@ -17,7 +17,7 @@ run_cargo("run", true)</string>
 	<key>keyEquivalent</key>
 	<string>@r</string>
 	<key>name</key>
-	<string>Cargo Run</string>
+	<string>Cargo Check</string>
 	<key>outputCaret</key>
 	<string>afterOutput</string>
 	<key>outputFormat</key>
@@ -29,7 +29,7 @@ run_cargo("run", true)</string>
 	<key>semanticClass</key>
 	<string>process.external.run.rust</string>
 	<key>uuid</key>
-	<string>22D8F169-BE9C-4E06-B704-83F388340324</string>
+	<string>C7735E1A-F4AF-4466-80D6-B2A942B70623</string>
 	<key>version</key>
 	<integer>2</integer>
 </dict>

--- a/Commands/Cargo Clippy.tmCommand
+++ b/Commands/Cargo Clippy.tmCommand
@@ -9,7 +9,7 @@
 
 require "#{ENV['TM_BUNDLE_SUPPORT']}/lib/build.rb"
 
-run_cargo("run", true)</string>
+run_cargo("clippy")</string>
 	<key>input</key>
 	<string>none</string>
 	<key>inputFormat</key>
@@ -17,7 +17,7 @@ run_cargo("run", true)</string>
 	<key>keyEquivalent</key>
 	<string>@r</string>
 	<key>name</key>
-	<string>Cargo Run</string>
+	<string>Cargo Clippy</string>
 	<key>outputCaret</key>
 	<string>afterOutput</string>
 	<key>outputFormat</key>
@@ -26,10 +26,8 @@ run_cargo("run", true)</string>
 	<string>newWindow</string>
 	<key>scope</key>
 	<string>attr.project.cargo</string>
-	<key>semanticClass</key>
-	<string>process.external.run.rust</string>
 	<key>uuid</key>
-	<string>22D8F169-BE9C-4E06-B704-83F388340324</string>
+	<string>74F21229-92E4-415A-A633-7E3C41B74C7D</string>
 	<key>version</key>
 	<integer>2</integer>
 </dict>

--- a/Commands/Cargo Fmt.tmCommand
+++ b/Commands/Cargo Fmt.tmCommand
@@ -5,11 +5,12 @@
 	<key>beforeRunningCommand</key>
 	<string>saveModifiedFiles</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby
+	<string>#!/bin/bash
 
-require "#{ENV['TM_BUNDLE_SUPPORT']}/lib/build.rb"
-
-run_cargo("run", true)</string>
+cd $TM_PROJECT_DIRECTORY
+: ${CARGO_HOME=$HOME/.cargo} &amp;&amp; export CARGO_HOME
+$CARGO_HOME/bin/cargo fmt -- --write-mode overwrite
+</string>
 	<key>input</key>
 	<string>none</string>
 	<key>inputFormat</key>
@@ -17,19 +18,19 @@ run_cargo("run", true)</string>
 	<key>keyEquivalent</key>
 	<string>@r</string>
 	<key>name</key>
-	<string>Cargo Run</string>
+	<string>Cargo Fmt</string>
 	<key>outputCaret</key>
-	<string>afterOutput</string>
+	<string>heuristic</string>
 	<key>outputFormat</key>
 	<string>html</string>
 	<key>outputLocation</key>
-	<string>newWindow</string>
+	<string>discard</string>
 	<key>scope</key>
 	<string>attr.project.cargo</string>
 	<key>semanticClass</key>
 	<string>process.external.run.rust</string>
 	<key>uuid</key>
-	<string>22D8F169-BE9C-4E06-B704-83F388340324</string>
+	<string>EE42F2F4-29B6-468E-ADA0-970D62B52F91</string>
 	<key>version</key>
 	<integer>2</integer>
 </dict>

--- a/Commands/Cargo Test.tmCommand
+++ b/Commands/Cargo Test.tmCommand
@@ -3,34 +3,19 @@
 <plist version="1.0">
 <dict>
 	<key>beforeRunningCommand</key>
-	<string>saveActiveFile</string>
+	<string>saveModifiedFiles</string>
 	<key>command</key>
-	<string>#!/bin/bash
-esc () {
-STR="$1" ruby18 &lt;&lt;"RUBY"
-   str = ENV['STR']
-   str = str.gsub(/'/, "'\\\\''")
-   str = str.gsub(/[\\"]/, '\\\\\\0')
-   print "'#{str}'"
-RUBY
-}
+	<string>#!/usr/bin/env ruby
 
-osascript &lt;&lt;- APPLESCRIPT
-	tell app "Terminal"
-	    launch
-	    activate
-	    do script "clear; cd $(esc "${TM_PROJECT_DIRECTORY:-$TM_DIRECTORY}")\ncargo test"
-	    set position of first window to { 100, 100 }
-	end tell
-APPLESCRIPT
+require "#{ENV['TM_BUNDLE_SUPPORT']}/lib/build.rb"
 
-</string>
+run_cargo("test", true)</string>
 	<key>input</key>
-	<string>document</string>
+	<string>none</string>
 	<key>inputFormat</key>
 	<string>text</string>
 	<key>keyEquivalent</key>
-	<string>@R</string>
+	<string>@r</string>
 	<key>name</key>
 	<string>Cargo Test</string>
 	<key>outputCaret</key>
@@ -38,9 +23,11 @@ APPLESCRIPT
 	<key>outputFormat</key>
 	<string>html</string>
 	<key>outputLocation</key>
-	<string>discard</string>
+	<string>newWindow</string>
 	<key>scope</key>
 	<string>attr.project.cargo</string>
+	<key>semanticClass</key>
+	<string>process.external.run.rust</string>
 	<key>uuid</key>
 	<string>CB93B58D-AAD0-453B-BF18-727E1D588A96</string>
 	<key>version</key>

--- a/Commands/Run.tmCommand
+++ b/Commands/Run.tmCommand
@@ -23,7 +23,7 @@ TextMate::Executor.run(args, :version_args =&gt; ["--version"],
 	<key>inputFormat</key>
 	<string>text</string>
 	<key>keyEquivalent</key>
-	<string>@r</string>
+	<string>@R</string>
 	<key>name</key>
 	<string>Run</string>
 	<key>outputCaret</key>

--- a/Preferences/Symbol List: No Function Call.tmPreferences
+++ b/Preferences/Symbol List: No Function Call.tmPreferences
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>name</key>
+	<string>Symbol List: No Function Call</string>
+	<key>scope</key>
+	<string>source.rust entity.name.function.rust.call</string>
+	<key>settings</key>
+	<dict>
+		<key>showInSymbolList</key>
+		<integer>0</integer>
+	</dict>
+	<key>uuid</key>
+	<string>93AA107D-930B-4EFB-B6F0-EDFB659554AB</string>
+</dict>
+</plist>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Rust TextMate2 Bundle
 
-A TextMate Bundle for the Rust programming langauage.
+A TextMate Bundle for the Rust programming language.
 
 ## Installation
 
@@ -40,19 +40,19 @@ tmb update rust
   </tr>
   <tr>
     <td>Build current file</td>
-    <td>cmd + b</td>
+    <td></td>
   </tr>
   <tr>
     <td>Build current file with tests</td>
-    <td>cmd + shift + b</td>
+    <td></td>
   </tr>
   <tr>
     <td>Run current file</td>
-    <td>cmd + r</td>
+    <td></td>
   </tr>
   <tr>
     <td>Run current file with tests</td>
-    <td>cmd + shift + r</td>
+    <td></td>
   </tr>
   <tr>
     <th colspan="2">
@@ -61,7 +61,7 @@ tmb update rust
   </tr>
   <tr>
     <td>Cargo build current project</td>
-    <td>cmd + b</td>
+    <td>cmd + r</td>
   </tr>
   <tr>
     <td>Cargo run current project</td>
@@ -69,7 +69,15 @@ tmb update rust
   </tr>
   <tr>
     <td>Cargo test current project</td>
-    <td>cmd + shift + r</td>
+    <td>cmd + r</td>
+  </tr>
+  <tr>
+    <td>Cargo check current project</td>
+    <td>cmd + r</td>
+  </tr>
+  <tr>
+    <td>Cargo format current project</td>
+    <td>cmd + r</td>
   </tr>
 </table>
 
@@ -87,6 +95,11 @@ tmb update rust
 - If you want your `racer` binary to be somewhere other than the locations in the last step, set the `TM_RACER` variable in your TextMate preferences to the location of your `racer` binary.
 - Set the `RUST_SRC_PATH` variable in your TextMate preferences to the location of your Rust source directory (the same location that you set this variable to as part of the racer installation instructions).
 
+## Support for cross compilation:
+
+So that this bundle can be used when cross compiling for [Fuchsia](https://fuchsia.googlesource.com/docs/+/HEAD/book.md), the `TM_CARGO_NAME` and `TM_CARGO_PARAMS` environmental variables can be used to cause the bundle to emit `fargo cargo -- check` instead of `cargo check`, for example. This could be extended to support other tools like
+[xargo](https://github.com/japaric/xargo) if there's any interest.
+
 ## Future Features:
 
 - Improved Syntax Highlighting
@@ -100,3 +113,4 @@ This bundle is licensed under the MIT License (LICENSE).
 * Copyright (c) 2012 [Tom Ellis](http://www.webmuse.co.uk/)
 * Copyright (c) 2014 [Elia Schito](http://elia.schito.me/)
 * Copyright (c) 2015 [Carol (Nichols || Goulding)](http://carol-nichols.com)
+* Copyright (c) 2017 Google Inc

--- a/Support/lib/build.rb
+++ b/Support/lib/build.rb
@@ -1,0 +1,68 @@
+require "#{ENV['TM_SUPPORT_PATH']}/lib/tm/executor"
+require "#{ENV['TM_SUPPORT_PATH']}/lib/tm/save_current_document"
+require "shellwords"
+require "json"
+require 'cgi'
+require 'pathname'
+
+
+def show_output(io, str)
+  io.puts("#{str}")
+end
+
+def run_cargo(cmd, use_extra_args = false)
+  additional_flags = []
+  default_dir = "src"
+  current_file_name = ENV['TM_FILEPATH'] || ""
+  current_file_name_without_extension = File.basename(current_file_name, ".rs")
+  current_file_dir = File.dirname(current_file_name)
+  current_file_dirname = File.basename(current_file_dir)
+  if current_file_dirname == "examples"
+    default_dir = "examples"
+    additional_flags = ["--example", current_file_name_without_extension] if use_extra_args
+  elsif current_file_dirname == "bin"
+    default_dir = "src/bin"
+    additional_flags = ["--bin", current_file_name_without_extension] if use_extra_args
+  end
+
+  TextMate.save_if_untitled('rs')
+  TextMate::Executor.make_project_master_current_document
+  TextMate::HTMLOutput.show(:title => "Cargo Build", :sub_title => "Results") do |io|
+    show_output(io, "<pre>")
+    cd_args = ["cd", ENV['TM_PROJECT_DIRECTORY']]
+    show_output(io, cd_args.join(" "))
+    TextMate::Process.run(cd_args)
+    cargo_home = ENV['CARGO_HOME']
+    cargo_name = ENV['TM_CARGO_NAME'] || "cargo"
+    cargo_params = (ENV['TM_CARGO_PARAMS'] || "").split(" ")
+    unless cargo_home
+      cargo_home = File.join(ENV['HOME'], ".cargo")
+    end
+    path_to_cargo = File.join(cargo_home, "bin", cargo_name)
+    unless File.exist? path_to_cargo
+      show_output(io, "Error: Cannot find cargo at #{path_to_cargo}. Check that cargo is \
+  installed and that the CARGO_HOME environmental variable is either unset or points \
+  to the right location.")
+      next
+    end
+    errors = []
+    args = [path_to_cargo, cargo_params, cmd, additional_flags]
+    show_output(io, args.join(" "))
+    TextMate::Process.run(args, :env => {"PWD" => ENV['TM_PROJECT_DIRECTORY']}) do |str, type|
+      if str =~ /--> (.*):(\d+):(\d+)/
+        file_ref = Pathname.new($1)
+        unless file_ref.absolute?
+          if file_ref.dirname == Pathname.new(".")
+            file_ref = File.join(ENV['TM_PROJECT_DIRECTORY'], default_dir, file_ref)
+          else
+            file_ref = File.join(ENV['TM_PROJECT_DIRECTORY'], file_ref)
+          end
+        end
+        show_output(io, "<a href=\"txmt://open/?url=file://#{file_ref}&line=#{$2}&column=#{$3}\">#{str}</a>")
+      else
+        show_output(io, str);
+      end
+    end
+    show_output(io, "</pre>")
+  end
+end

--- a/Syntaxes/Rust.tmLanguage
+++ b/Syntaxes/Rust.tmLanguage
@@ -291,7 +291,7 @@
 				<key>1</key>
 				<dict>
 					<key>name</key>
-					<string>entity.name.function.rust</string>
+					<string>entity.name.function.rust.call</string>
 				</dict>
 			</dict>
 			<key>comment</key>

--- a/info.plist
+++ b/info.plist
@@ -19,7 +19,10 @@
 			<string>------------------------------------</string>
 			<string>22D8F169-BE9C-4E06-B704-83F388340324</string>
 			<string>D5624A49-9460-43C7-9D05-39580911371C</string>
+			<string>C7735E1A-F4AF-4466-80D6-B2A942B70623</string>
 			<string>CB93B58D-AAD0-453B-BF18-727E1D588A96</string>
+			<string>EE42F2F4-29B6-468E-ADA0-970D62B52F91</string>
+			<string>74F21229-92E4-415A-A633-7E3C41B74C7D</string>
 			<string>------------------------------------</string>
 			<string>5D83E339-418A-42FB-A6A4-37B8FAA3690E</string>
 			<string>23E9CFF0-E905-48A1-AF7F-4DC5497E0352</string>


### PR DESCRIPTION
Makes the cargo commands produce output in an HTML window, so that error messages are clickable. It also adds cargo check, cargo fmt and cargo clippy commands.

To support so many new commands the bundle now uses the single shortcut key approach.

Also has changes under the hood to support using the bundle for Fuchsia development and a refinement of the symbol list.