### PR TITLE
Made the error code link to the Rust Compiler Error Index

### DIFF
--- a/Support/lib/build.rb
+++ b/Support/lib/build.rb
@@ -59,6 +59,8 @@ def run_cargo(cmd, use_extra_args = false)
           end
         end
         show_output(io, "<a href=\"txmt://open/?url=file://#{file_ref}&line=#{$2}&column=#{$3}\">#{str}</a>")
+      elsif str =~ /error\[E(\d\d\d\d)\]/
+        show_output(io, "<a href=\"https://doc.rust-lang.org/error-index.html\#E#{$1}\" target=\"_blank\">#{str}</a>")
       else
         show_output(io, str);
       end


### PR DESCRIPTION
The descriptions at the Rust Compiler Error Index are often very helpful so
make the bundle convert the E-codes to a clickable link.