### PR TITLE
Add `const`.

### DIFF
--- a/Syntaxes/Rust.tmLanguage
+++ b/Syntaxes/Rust.tmLanguage
@@ -165,6 +165,14 @@
 		</dict>
 		<dict>
 			<key>comment</key>
+			<string>Const storage modifier</string>
+			<key>match</key>
+			<string>\bconst\b</string>
+			<key>name</key>
+			<string>storage.modifier.const.rust</string>
+		</dict>
+		<dict>
+			<key>comment</key>
 			<string>Static storage modifier</string>
 			<key>match</key>
 			<string>\bstatic\b</string>


### PR DESCRIPTION
This adds syntax highlighting for the `const` keyword.