### PR TITLE
Workspace root and formatting fixes

### DIFF
--- a/Commands/Cargo Clippy.tmCommand
+++ b/Commands/Cargo Clippy.tmCommand
@@ -9,7 +9,7 @@
 
 require "#{ENV['TM_BUNDLE_SUPPORT']}/lib/build.rb"
 
-run_cargo("clippy")</string>
+run_cargo("clippy", false, true)</string>
 	<key>input</key>
 	<string>none</string>
 	<key>inputFormat</key>

--- a/Commands/Cargo Fmt.tmCommand
+++ b/Commands/Cargo Fmt.tmCommand
@@ -9,7 +9,7 @@
 
 cd $TM_PROJECT_DIRECTORY
 : ${CARGO_HOME=$HOME/.cargo} &amp;&amp; export CARGO_HOME
-$CARGO_HOME/bin/cargo fmt -- --write-mode overwrite
+$CARGO_HOME/bin/cargo +nightly fmt
 </string>
 	<key>input</key>
 	<string>none</string>

--- a/Commands/Format.tmCommand
+++ b/Commands/Format.tmCommand
@@ -9,7 +9,7 @@
 
 cd $TM_PROJECT_DIRECTORY
 : ${CARGO_HOME=$HOME/.cargo} &amp;&amp; export CARGO_HOME
-$CARGO_HOME/bin/rustfmt --write-mode overwrite $TM_FILEPATH
+$CARGO_HOME/bin/rustfmt $TM_FILEPATH
 </string>
 	<key>input</key>
 	<string>none</string>

--- a/Commands/Format.tmCommand
+++ b/Commands/Format.tmCommand
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>beforeRunningCommand</key>
+	<string>saveActiveFile</string>
+	<key>command</key>
+	<string>#!/bin/bash
+
+cd $TM_PROJECT_DIRECTORY
+: ${CARGO_HOME=$HOME/.cargo} &amp;&amp; export CARGO_HOME
+$CARGO_HOME/bin/rustfmt --write-mode overwrite $TM_FILEPATH
+</string>
+	<key>input</key>
+	<string>none</string>
+	<key>inputFormat</key>
+	<string>text</string>
+	<key>keyEquivalent</key>
+	<string>@R</string>
+	<key>name</key>
+	<string>Format</string>
+	<key>outputCaret</key>
+	<string>afterOutput</string>
+	<key>outputFormat</key>
+	<string>text</string>
+	<key>outputLocation</key>
+	<string>discard</string>
+	<key>scope</key>
+	<string>source.rust</string>
+	<key>uuid</key>
+	<string>62C653C0-B18A-4B68-9598-32972B821814</string>
+	<key>version</key>
+	<integer>2</integer>
+</dict>
+</plist>

--- a/Support/lib/build.rb
+++ b/Support/lib/build.rb
@@ -30,7 +30,7 @@ def get_worspace_root(cargo_home)
   workspace_root
 end
 
-def run_cargo(cmd, use_extra_args = false)
+def run_cargo(cmd, use_extra_args = false, use_nightly = false)
   additional_flags = []
   default_dir = "src"
   current_file_name = ENV['TM_FILEPATH'] || ""
@@ -67,6 +67,9 @@ def run_cargo(cmd, use_extra_args = false)
     end
     workspace_root = get_worspace_root(cargo_home)
     errors = []
+    if use_nightly
+      cargo_params.insert(0, "+nightly")
+    end
     args = [path_to_cargo, cargo_params, cmd, additional_flags]
     show_output(io, args.join(" "))
     TextMate::Process.run(args, :env => {"PWD" => ENV['TM_PROJECT_DIRECTORY']}) do |str, type|

--- a/Support/lib/build.rb
+++ b/Support/lib/build.rb
@@ -10,6 +10,26 @@ def show_output(io, str)
   io.puts("#{str}")
 end
 
+# Try to use cargo metadata to find the workspace
+# root for resolving relative paths in error messages.
+# Fall back to TM_PROJECT_DIRECTORY if that attempt
+# fails for any reason.
+def get_worspace_root(cargo_home)
+  workspace_root = nil
+  begin
+    path_to_cargo = File.join(cargo_home, "bin", "cargo")
+    metadata_json = nil
+    IO.popen([path_to_cargo, "metadata", "--no-deps", "--format-version", "1", :err=>[:child, :out]]) {|ls_io|
+      metadata_json = ls_io.read
+    }
+    metadata = JSON.parse(metadata_json)
+    workspace_root = metadata["workspace_root"]
+  rescue
+    workspace_root = ENV['TM_PROJECT_DIRECTORY']
+  end
+  workspace_root
+end
+
 def run_cargo(cmd, use_extra_args = false)
   additional_flags = []
   default_dir = "src"
@@ -45,6 +65,7 @@ def run_cargo(cmd, use_extra_args = false)
   to the right location.")
       next
     end
+    workspace_root = get_worspace_root(cargo_home)
     errors = []
     args = [path_to_cargo, cargo_params, cmd, additional_flags]
     show_output(io, args.join(" "))
@@ -53,9 +74,9 @@ def run_cargo(cmd, use_extra_args = false)
         file_ref = Pathname.new($1)
         unless file_ref.absolute?
           if file_ref.dirname == Pathname.new(".")
-            file_ref = File.join(ENV['TM_PROJECT_DIRECTORY'], default_dir, file_ref)
+            file_ref = File.join(workspace_root, default_dir, file_ref)
           else
-            file_ref = File.join(ENV['TM_PROJECT_DIRECTORY'], file_ref)
+            file_ref = File.join(workspace_root, file_ref)
           end
         end
         show_output(io, "<a href=\"txmt://open/?url=file://#{file_ref}&line=#{$2}&column=#{$3}\">#{str}</a>")

--- a/info.plist
+++ b/info.plist
@@ -16,6 +16,7 @@
 			<string>A7DF7817-C437-464D-9A12-BA23CB4AE9B9</string>
 			<string>AE3EDDD9-4C26-4107-AFB3-23E80044C531</string>
 			<string>299EB188-E7AE-4C55-BBCE-17EA4337F3FA</string>
+			<string>62C653C0-B18A-4B68-9598-32972B821814</string>
 			<string>------------------------------------</string>
 			<string>22D8F169-BE9C-4E06-B704-83F388340324</string>
 			<string>D5624A49-9460-43C7-9D05-39580911371C</string>


### PR DESCRIPTION
One change is related to using the workspace root to translate error message paths to full paths. The rest are related to changes in clippy and rustfmt and adding a command to format a single file.