### PR TITLE
Use `:chdir` option instead of setting `PWD`.

### DIFF
--- a/Support/lib/build.rb
+++ b/Support/lib/build.rb
@@ -48,7 +48,7 @@ def run_cargo(cmd, use_extra_args = false)
     errors = []
     args = [path_to_cargo, cargo_params, cmd, additional_flags]
     show_output(io, args.join(" "))
-    TextMate::Process.run(args, :env => {"PWD" => ENV['TM_PROJECT_DIRECTORY']}) do |str, type|
+    TextMate::Process.run(args, :chdir => ENV['TM_PROJECT_DIRECTORY']) do |str, type|
       if str =~ /--> (.*):(\d+):(\d+)/
         file_ref = Pathname.new($1)
         unless file_ref.absolute?


### PR DESCRIPTION
Without this change I am getting the following error when running any of the `cargo` commands:

```
error: could not find `Cargo.toml` in `/private/var/folders/k1/mgz9q5xj2z3522rc76w_h21w0000gn/T` or any parent directory
```

This is because `cargo` does not seem to use the `PWD` variable. With the `:chdir` option, it actually changes the directory.