### PR TITLE
Add `i128` and `u128` to `storage.type.rust`.

### DIFF
--- a/Syntaxes/Rust.tmLanguage
+++ b/Syntaxes/Rust.tmLanguage
@@ -706,7 +706,7 @@
 			<key>comment</key>
 			<string>Built-in type</string>
 			<key>match</key>
-			<string>\b(bool|char|usize|isize|u8|u16|u32|u64|i8|i16|i32|i64|f32|f64|str|Self)\b</string>
+			<string>\b(bool|char|usize|isize|u8|u16|u32|u64|u128|i8|i16|i32|i64|i128|f32|f64|str|Self)\b</string>
 			<key>name</key>
 			<string>storage.type.rust</string>
 		</dict>


### PR DESCRIPTION
Numeric literals like `7i128` and `7u128` are already highlighted, but bare `i128` and `u128` types are still missing syntax highlighting.