### PR TITLE
Fix Ruby 2.6 ERB trim mode warning

### DIFF
--- a/Commands/Cargo Build.tmCommand
+++ b/Commands/Cargo Build.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>saveModifiedFiles</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby
+	<string>#!/usr/bin/env ruby20
 
 require "#{ENV['TM_BUNDLE_SUPPORT']}/lib/build.rb"
 

--- a/Commands/Cargo Check.tmCommand
+++ b/Commands/Cargo Check.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>saveModifiedFiles</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby
+	<string>#!/usr/bin/env ruby20
 
 require "#{ENV['TM_BUNDLE_SUPPORT']}/lib/build.rb"
 

--- a/Commands/Cargo Clippy.tmCommand
+++ b/Commands/Cargo Clippy.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>saveModifiedFiles</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby
+	<string>#!/usr/bin/env ruby20
 
 require "#{ENV['TM_BUNDLE_SUPPORT']}/lib/build.rb"
 

--- a/Commands/Cargo Test.tmCommand
+++ b/Commands/Cargo Test.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>saveModifiedFiles</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby
+	<string>#!/usr/bin/env ruby20
 
 require "#{ENV['TM_BUNDLE_SUPPORT']}/lib/build.rb"
 

--- a/Commands/Run with Cargo (external).tmCommand
+++ b/Commands/Run with Cargo (external).tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>saveModifiedFiles</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby
+	<string>#!/usr/bin/env ruby20
 
 require "#{ENV['TM_BUNDLE_SUPPORT']}/lib/build.rb"
 


### PR DESCRIPTION
This PR fixes an incompatibility introduced by Ruby 2.6 in the ERB class, which [deprecates certain combinations of trim mode specifiers](https://redmine.ruby-lang.org/issues/15294), such as `%-<>`.

This causes TextMate’s Bundle Support library (which [uses the `%-<>` trim mode specifier](https://github.com/textmate/bundle-support.tmbundle/blob/39042ef25cc5603054eee11f27c2ea91d54a6cdf/Support/shared/lib/tm/htmloutput.rb#L91)) to [print a warning](https://redmine.ruby-lang.org/attachments/7457) when run via Ruby 2.6:

![image](https://user-images.githubusercontent.com/1239874/57146110-e258d180-6dc4-11e9-9357-39ee96bc0b78.png)

The workaround proposed here is to use the `ruby20` shim, which points to system Ruby 2.3 as of macOS 10.14. [That’s how other TextMate bundles do it](https://github.com/search?q=org%3Atextmate+ruby20&type=Code) if they depend on some post-1.8 feature (such as `json`) but still need some legacy behavior.

Future macOS versions may re-introduce this issue if they come with Ruby 2.6 or later. [That will also affect other TextMate bundles](https://github.com/search?q=org%3Atextmate+ruby20&type=Code). In that case, we’re going to need alternative fixes, for example [vendoring a pure-Ruby JSON library](https://github.com/textmate/sql.tmbundle/blob/6d4edbc113d3272f7c097d6b1504624289ee2bc5/Support/lib/json.rb) or even vendoring Ruby itself (like TextMate does with Ruby 1.8 today).
