### PR TITLE
Fix wrong syntax highlighting of lifetimes.

### DIFF
--- a/Syntaxes/Rust.tmLanguage
+++ b/Syntaxes/Rust.tmLanguage
@@ -613,7 +613,7 @@
 			<key>comment</key>
 			<string>Named lifetime</string>
 			<key>match</key>
-			<string>'([a-zA-Z_][a-zA-Z0-9_]*)\b[^']</string>
+			<string>'([a-zA-Z_][a-zA-Z0-9_]*)\b(?!')</string>
 			<key>name</key>
 			<string>storage.modifier.lifetime.rust</string>
 		</dict>


### PR DESCRIPTION
Before:

<img width="161" alt="Bildschirmfoto 2020-03-04 um 17 01 02" src="https://user-images.githubusercontent.com/1309829/75898144-f54f8e80-5e39-11ea-8312-c340b130abe3.png">

After:

<img width="139" alt="Bildschirmfoto 2020-03-04 um 17 02 51" src="https://user-images.githubusercontent.com/1309829/75898177-ff718d00-5e39-11ea-9c37-ec6fb9977af8.png">
