### PR TITLE
Add better support for finding cargo binary

### DIFF
--- a/Support/lib/build.rb
+++ b/Support/lib/build.rb
@@ -32,8 +32,8 @@ end
 def get_cargo_bin
   paths_to_cargo = [
     ENV['TM_CARGO'].to_s,
-    File.join(cargo_home, 'bin', 'cargo'),
-    `which cargo`.chomp
+    File.join(cargo_home, 'bin', cargo_name),
+    `which #{cargo_name}`.chomp
   ].reject(&:empty?)
 
   path_to_cargo = paths_to_cargo.find {|path| File.exists?(path) }


### PR DESCRIPTION
Instead of just trying to find cargo within `$HOME/.cargo/bin` or
`$CARGO_HOME/bin`, we now check the `TM_CARGO` environment variable and
if cargo is available in the user's `PATH`.

This is helpful if `cargo` is found somewhere else, e.g., `$HOME/.asdf/shims/cargo`, which is the case if you're using the [asdf version manager](https://asdf-vm.com/).