### PR TITLE
No need to require nightly for cargo clippy

### DIFF
--- a/Commands/Cargo Clippy.tmCommand
+++ b/Commands/Cargo Clippy.tmCommand
@@ -9,7 +9,7 @@
 
 require "#{ENV['TM_BUNDLE_SUPPORT']}/lib/build.rb"
 
-run_cargo("clippy", false, true)</string>
+run_cargo("clippy")</string>
 	<key>input</key>
 	<string>none</string>
 	<key>inputFormat</key>


### PR DESCRIPTION
As of Rust 1.29, clippy is supported in stable.